### PR TITLE
Remove .github folder

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-If this is a question or feature request, make sure to:
-
-- [ ] The title starts with `Question:` or `Feature:`.
-
-If this is an bug report, not a question, make sure to:
-
-- [ ] I'm not running Windows (which is unsupported), or if I am, I can confirm this issue appears on another platform, or Vagrant.
-- [ ] This issue appears in the latest `dev` branch.
-- [ ] I've included my browser and Ruby version in this issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-!!!!! STOP AND READ !!!!!
-
-If the dropdown above says "base fork: lord/master", you are submitting your change to ALL USERS OF SLATE, not just your company. This is probably not what you want. Click "base fork" to change it to the right place.
-
-If you're actually trying to submit a change to upstream Slate, please submit to our dev branch, PRs sent to the master branch are generally rejected.


### PR DESCRIPTION
Removes the .github folder that relates to settings for the original slate project